### PR TITLE
Support streams in stores and northbound APIs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,11 @@ go 1.13
 
 require (
 	github.com/docker/docker v1.13.1
+	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/gogo/protobuf v1.3.1
+	github.com/googleapis/gnostic v0.3.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect
+	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onosproject/onos-test v0.0.0-20200212201952-fb8d2ac644a0
 	github.com/onosproject/onos-topo v0.0.0-20200203171043-cf2700039848

--- a/pkg/apps/onos-ran-ho/handover/handover.go
+++ b/pkg/apps/onos-ran-ho/handover/handover.go
@@ -20,11 +20,11 @@ import (
 )
 
 // HODecisionMaker decide whether the UE in UELinkInfo should do handover or not
-func HODecisionMaker(ueinfo *[]nb.UELinkInfo) *[]nb.HandOverRequest {
+func HODecisionMaker(ueinfo []*nb.UELinkInfo) []*nb.HandOverRequest {
 
-	var resultHoReqs []nb.HandOverRequest
+	var resultHoReqs []*nb.HandOverRequest
 
-	for _, l := range *ueinfo {
+	for _, l := range ueinfo {
 		servStationID := l.GetEcgi()
 		numNeighborCells := len(l.GetChannelQualities())
 		bestStationID := l.GetChannelQualities()[0].GetTargetEcgi()
@@ -43,7 +43,7 @@ func HODecisionMaker(ueinfo *[]nb.UELinkInfo) *[]nb.HandOverRequest {
 			continue
 		}
 
-		hoReq := nb.HandOverRequest{
+		hoReq := &nb.HandOverRequest{
 			Crnti: l.GetCrnti(),
 			SrcStation: &nb.ECGI{
 				Plmnid: servStationID.GetPlmnid(),
@@ -56,5 +56,5 @@ func HODecisionMaker(ueinfo *[]nb.UELinkInfo) *[]nb.HandOverRequest {
 		}
 		resultHoReqs = append(resultHoReqs, hoReq)
 	}
-	return &resultHoReqs
+	return resultHoReqs
 }

--- a/pkg/apps/onos-ran-ho/handover/handover_test.go
+++ b/pkg/apps/onos-ran-ho/handover/handover_test.go
@@ -26,39 +26,39 @@ import (
 // Case 1. Serving station is the best one
 func TestHODecisionMakerCase1(t *testing.T) {
 	var cqV1 []*nb.ChannelQuality
-	cqV1S := nb.ChannelQuality{
+	cqV1S := &nb.ChannelQuality{
 		TargetEcgi: &nb.ECGI{
 			Plmnid: "315010",
 			Ecid:   "0001",
 		},
 		CqiHist: 15,
 	}
-	cqV1 = append(cqV1, &cqV1S)
-	cqV1N1 := nb.ChannelQuality{
+	cqV1 = append(cqV1, cqV1S)
+	cqV1N1 := &nb.ChannelQuality{
 		TargetEcgi: &nb.ECGI{
 			Plmnid: "315010",
 			Ecid:   "0002",
 		},
 		CqiHist: 12,
 	}
-	cqV1 = append(cqV1, &cqV1N1)
-	cqV1N2 := nb.ChannelQuality{
+	cqV1 = append(cqV1, cqV1N1)
+	cqV1N2 := &nb.ChannelQuality{
 		TargetEcgi: &nb.ECGI{
 			Plmnid: "315010",
 			Ecid:   "0003",
 		},
 		CqiHist: 11,
 	}
-	cqV1 = append(cqV1, &cqV1N2)
-	cqV1N3 := nb.ChannelQuality{
+	cqV1 = append(cqV1, cqV1N2)
+	cqV1N3 := &nb.ChannelQuality{
 		TargetEcgi: &nb.ECGI{
 			Plmnid: "315010",
 			Ecid:   "0004",
 		},
 		CqiHist: 1,
 	}
-	cqV1 = append(cqV1, &cqV1N3)
-	value1 := nb.UELinkInfo{
+	cqV1 = append(cqV1, cqV1N3)
+	value1 := &nb.UELinkInfo{
 		Crnti: "1",
 		Ecgi: &nb.ECGI{
 			Plmnid: "315010",
@@ -66,9 +66,9 @@ func TestHODecisionMakerCase1(t *testing.T) {
 		},
 		ChannelQualities: cqV1,
 	}
-	listValue := []nb.UELinkInfo{value1}
-	hoReqV1 := HODecisionMaker(&listValue)
-	assert.Nil(t, *hoReqV1)
+	listValue := []*nb.UELinkInfo{value1}
+	hoReqV1 := HODecisionMaker(listValue)
+	assert.Nil(t, hoReqV1)
 }
 
 // Case 2-1. 1st neighbor station is the best one
@@ -76,39 +76,39 @@ func TestHODecisionMakerCase2Dot1(t *testing.T) {
 
 	v2TargetECID := "0002"
 	var cqV2 []*nb.ChannelQuality
-	cqV2S := nb.ChannelQuality{
+	cqV2S := &nb.ChannelQuality{
 		TargetEcgi: &nb.ECGI{
 			Plmnid: "315010",
 			Ecid:   "0001",
 		},
 		CqiHist: 10,
 	}
-	cqV2 = append(cqV2, &cqV2S)
-	cqV2N1 := nb.ChannelQuality{
+	cqV2 = append(cqV2, cqV2S)
+	cqV2N1 := &nb.ChannelQuality{
 		TargetEcgi: &nb.ECGI{
 			Plmnid: "315010",
 			Ecid:   "0002",
 		},
 		CqiHist: 12,
 	}
-	cqV2 = append(cqV2, &cqV2N1)
-	cqV2N2 := nb.ChannelQuality{
+	cqV2 = append(cqV2, cqV2N1)
+	cqV2N2 := &nb.ChannelQuality{
 		TargetEcgi: &nb.ECGI{
 			Plmnid: "315010",
 			Ecid:   "0003",
 		},
 		CqiHist: 11,
 	}
-	cqV2 = append(cqV2, &cqV2N2)
-	cqV2N3 := nb.ChannelQuality{
+	cqV2 = append(cqV2, cqV2N2)
+	cqV2N3 := &nb.ChannelQuality{
 		TargetEcgi: &nb.ECGI{
 			Plmnid: "315010",
 			Ecid:   "0004",
 		},
 		CqiHist: 1,
 	}
-	cqV2 = append(cqV2, &cqV2N3)
-	value2 := nb.UELinkInfo{
+	cqV2 = append(cqV2, cqV2N3)
+	value2 := &nb.UELinkInfo{
 		Crnti: "1",
 		Ecgi: &nb.ECGI{
 			Plmnid: "315010",
@@ -116,9 +116,9 @@ func TestHODecisionMakerCase2Dot1(t *testing.T) {
 		},
 		ChannelQualities: cqV2,
 	}
-	listValue := []nb.UELinkInfo{value2}
-	hoReqV2 := HODecisionMaker(&listValue)
-	assert.Equal(t, (*hoReqV2)[0].GetDstStation().GetEcid(), v2TargetECID)
+	listValue := []*nb.UELinkInfo{value2}
+	hoReqV2 := HODecisionMaker(listValue)
+	assert.Equal(t, (hoReqV2)[0].GetDstStation().GetEcid(), v2TargetECID)
 }
 
 // Case 2-2. 2nd neighbor station is the best one
@@ -126,39 +126,39 @@ func TestHODecisionMakerCase2Dot2(t *testing.T) {
 
 	v2TargetECID := "0003"
 	var cqV2 []*nb.ChannelQuality
-	cqV2S := nb.ChannelQuality{
+	cqV2S := &nb.ChannelQuality{
 		TargetEcgi: &nb.ECGI{
 			Plmnid: "315010",
 			Ecid:   "0001",
 		},
 		CqiHist: 10,
 	}
-	cqV2 = append(cqV2, &cqV2S)
-	cqV2N1 := nb.ChannelQuality{
+	cqV2 = append(cqV2, cqV2S)
+	cqV2N1 := &nb.ChannelQuality{
 		TargetEcgi: &nb.ECGI{
 			Plmnid: "315010",
 			Ecid:   "0002",
 		},
 		CqiHist: 9,
 	}
-	cqV2 = append(cqV2, &cqV2N1)
-	cqV2N2 := nb.ChannelQuality{
+	cqV2 = append(cqV2, cqV2N1)
+	cqV2N2 := &nb.ChannelQuality{
 		TargetEcgi: &nb.ECGI{
 			Plmnid: "315010",
 			Ecid:   "0003",
 		},
 		CqiHist: 11,
 	}
-	cqV2 = append(cqV2, &cqV2N2)
-	cqV2N3 := nb.ChannelQuality{
+	cqV2 = append(cqV2, cqV2N2)
+	cqV2N3 := &nb.ChannelQuality{
 		TargetEcgi: &nb.ECGI{
 			Plmnid: "315010",
 			Ecid:   "0004",
 		},
 		CqiHist: 1,
 	}
-	cqV2 = append(cqV2, &cqV2N3)
-	value2 := nb.UELinkInfo{
+	cqV2 = append(cqV2, cqV2N3)
+	value2 := &nb.UELinkInfo{
 		Crnti: "1",
 		Ecgi: &nb.ECGI{
 			Plmnid: "315010",
@@ -166,9 +166,9 @@ func TestHODecisionMakerCase2Dot2(t *testing.T) {
 		},
 		ChannelQualities: cqV2,
 	}
-	listValue := []nb.UELinkInfo{value2}
-	hoReqV2 := HODecisionMaker(&listValue)
-	assert.Equal(t, (*hoReqV2)[0].GetDstStation().GetEcid(), v2TargetECID)
+	listValue := []*nb.UELinkInfo{value2}
+	hoReqV2 := HODecisionMaker(listValue)
+	assert.Equal(t, hoReqV2[0].GetDstStation().GetEcid(), v2TargetECID)
 }
 
 // Case 2-3. 3rd neighbor station is the best one
@@ -176,39 +176,39 @@ func TestHODecisionMakerCase2Dot3(t *testing.T) {
 
 	v2TargetECID := "0004"
 	var cqV2 []*nb.ChannelQuality
-	cqV2S := nb.ChannelQuality{
+	cqV2S := &nb.ChannelQuality{
 		TargetEcgi: &nb.ECGI{
 			Plmnid: "315010",
 			Ecid:   "0001",
 		},
 		CqiHist: 10,
 	}
-	cqV2 = append(cqV2, &cqV2S)
-	cqV2N1 := nb.ChannelQuality{
+	cqV2 = append(cqV2, cqV2S)
+	cqV2N1 := &nb.ChannelQuality{
 		TargetEcgi: &nb.ECGI{
 			Plmnid: "315010",
 			Ecid:   "0002",
 		},
 		CqiHist: 9,
 	}
-	cqV2 = append(cqV2, &cqV2N1)
-	cqV2N2 := nb.ChannelQuality{
+	cqV2 = append(cqV2, cqV2N1)
+	cqV2N2 := &nb.ChannelQuality{
 		TargetEcgi: &nb.ECGI{
 			Plmnid: "315010",
 			Ecid:   "0003",
 		},
 		CqiHist: 11,
 	}
-	cqV2 = append(cqV2, &cqV2N2)
-	cqV2N3 := nb.ChannelQuality{
+	cqV2 = append(cqV2, cqV2N2)
+	cqV2N3 := &nb.ChannelQuality{
 		TargetEcgi: &nb.ECGI{
 			Plmnid: "315010",
 			Ecid:   "0004",
 		},
 		CqiHist: 15,
 	}
-	cqV2 = append(cqV2, &cqV2N3)
-	value2 := nb.UELinkInfo{
+	cqV2 = append(cqV2, cqV2N3)
+	value2 := &nb.UELinkInfo{
 		Crnti: "1",
 		Ecgi: &nb.ECGI{
 			Plmnid: "315010",
@@ -216,7 +216,7 @@ func TestHODecisionMakerCase2Dot3(t *testing.T) {
 		},
 		ChannelQualities: cqV2,
 	}
-	listValue := []nb.UELinkInfo{value2}
-	hoReqV2 := HODecisionMaker(&listValue)
-	assert.Equal(t, (*hoReqV2)[0].GetDstStation().GetEcid(), v2TargetECID)
+	listValue := []*nb.UELinkInfo{value2}
+	hoReqV2 := HODecisionMaker(listValue)
+	assert.Equal(t, hoReqV2[0].GetDstStation().GetEcid(), v2TargetECID)
 }

--- a/pkg/apps/onos-ran-ho/southbound/c1.go
+++ b/pkg/apps/onos-ran-ho/southbound/c1.go
@@ -153,7 +153,7 @@ func (m *HOSessions) containUeLinkLists(pList []*nb.UELinkInfo, cList []*nb.UELi
 
 // getListUELinks gets the list of link between each UE and serving/neighbor stations, and call sendHandoverTrigger if HO is necessary.
 func (m *HOSessions) watchUELinks(ch chan<- []*nb.UELinkInfo) error {
-	ueLinks := make(map[UELinkID]*nb.UELinkInfo)
+	ueLinks := make(map[ueLinkID]*nb.UELinkInfo)
 
 	stream, err := m.client.ListUELinks(context.Background(), &nb.UELinkListRequest{Subscribe: true})
 	if err != nil {
@@ -172,7 +172,7 @@ func (m *HOSessions) watchUELinks(ch chan<- []*nb.UELinkInfo) error {
 				break
 			}
 
-			id := UELinkID{
+			id := ueLinkID{
 				PlmnID: ueInfo.Ecgi.Plmnid,
 				Ecid:   ueInfo.Ecgi.Ecid,
 				Crnti:  ueInfo.Crnti,
@@ -189,7 +189,7 @@ func (m *HOSessions) watchUELinks(ch chan<- []*nb.UELinkInfo) error {
 	return nil
 }
 
-type UELinkID struct {
+type ueLinkID struct {
 	PlmnID string
 	Ecid   string
 	Crnti  string

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -91,9 +91,19 @@ func (m *Manager) GetControlUpdates() ([]sb.ControlUpdate, error) {
 	return m.updatesStore.List(), nil
 }
 
+// SubscribeControlUpdates subscribes the given channel to control updates
+func (m *Manager) SubscribeControlUpdates(ch chan<- sb.ControlUpdate) error {
+	return m.updatesStore.Watch(ch, updates.WithReplay())
+}
+
 // GetTelemetry gets telemeter messages
 func (m *Manager) GetTelemetry() ([]sb.TelemetryMessage, error) {
 	return m.telemetryStore.List(), nil
+}
+
+// SubscribeTelemetry subscribes the given channel to telemetry events
+func (m *Manager) SubscribeTelemetry(ch chan<- sb.TelemetryMessage) error {
+	return m.telemetryStore.Watch(ch, telemetry.WithReplay())
 }
 
 // Run starts a synchronizer based on the devices and the northbound services.

--- a/pkg/store/telemetry/store.go
+++ b/pkg/store/telemetry/store.go
@@ -128,8 +128,8 @@ func (s *telemetryStore) Put(telemetry sb.TelemetryMessage) error {
 	id := getKey(telemetry)
 	s.mu.Lock()
 	s.telemetry[id] = telemetry
-	s.mu.Unlock()
 	s.enqueueEvent(telemetry)
+	s.mu.Unlock()
 	return nil
 }
 
@@ -154,6 +154,7 @@ func (s *telemetryStore) Watch(ch chan<- sb.TelemetryMessage, opts ...WatchOptio
 	done := make(chan struct{})
 	go func() {
 		s.mu.Lock()
+		close(done)
 		if options.replay {
 			for _, telemetry := range s.telemetry {
 				ch <- telemetry
@@ -161,7 +162,6 @@ func (s *telemetryStore) Watch(ch chan<- sb.TelemetryMessage, opts ...WatchOptio
 		}
 		s.watchers = append(s.watchers, ch)
 		s.mu.Unlock()
-		close(done)
 	}()
 	<-done
 	return nil

--- a/pkg/store/telemetry/store_test.go
+++ b/pkg/store/telemetry/store_test.go
@@ -23,13 +23,13 @@ import (
 
 func TestStore(t *testing.T) {
 	testStore, err := NewStore()
+	assert.NoError(t, err)
+	assert.NotNil(t, testStore)
 
 	watchCh1 := make(chan sb.TelemetryMessage)
 	err = testStore.Watch(watchCh1)
 	assert.NoError(t, err)
 
-	assert.Nil(t, err)
-	assert.NotNil(t, testStore)
 	telemetry1 := sb.TelemetryMessage{
 		MessageType: sb.MessageType_RADIO_MEAS_REPORT_PER_CELL,
 		S: &sb.TelemetryMessage_RadioMeasReportPerCell{
@@ -62,6 +62,7 @@ func TestStore(t *testing.T) {
 
 	watchCh2 := make(chan sb.TelemetryMessage)
 	err = testStore.Watch(watchCh2, WithReplay())
+	assert.NoError(t, err)
 
 	event = <-watchCh2
 	assert.Equal(t, "test-ecid", event.GetRadioMeasReportPerCell().Ecgi.Ecid)

--- a/pkg/store/telemetry/store_test.go
+++ b/pkg/store/telemetry/store_test.go
@@ -23,6 +23,11 @@ import (
 
 func TestStore(t *testing.T) {
 	testStore, err := NewStore()
+
+	watchCh1 := make(chan sb.TelemetryMessage)
+	err = testStore.Watch(watchCh1)
+	assert.NoError(t, err)
+
 	assert.Nil(t, err)
 	assert.NotNil(t, testStore)
 	telemetry1 := sb.TelemetryMessage{
@@ -51,6 +56,17 @@ func TestStore(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, value1.MessageType.String(), sb.MessageType_RADIO_MEAS_REPORT_PER_CELL.String())
 
+	event := <-watchCh1
+	assert.Equal(t, "test-ecid", event.GetRadioMeasReportPerCell().Ecgi.Ecid)
+	assert.Equal(t, "test-plmnid", event.GetRadioMeasReportPerCell().Ecgi.PlmnId)
+
+	watchCh2 := make(chan sb.TelemetryMessage)
+	err = testStore.Watch(watchCh2, WithReplay())
+
+	event = <-watchCh2
+	assert.Equal(t, "test-ecid", event.GetRadioMeasReportPerCell().Ecgi.Ecid)
+	assert.Equal(t, "test-plmnid", event.GetRadioMeasReportPerCell().Ecgi.PlmnId)
+
 	telemetry2 := sb.TelemetryMessage{
 		MessageType: sb.MessageType_RADIO_MEAS_REPORT_PER_CELL,
 		S: &sb.TelemetryMessage_RadioMeasReportPerCell{
@@ -77,6 +93,14 @@ func TestStore(t *testing.T) {
 	value2, err := testStore.Get(id2)
 	assert.Nil(t, err)
 	assert.Equal(t, value2.MessageType.String(), sb.MessageType_RADIO_MEAS_REPORT_PER_CELL.String())
+
+	event = <-watchCh1
+	assert.Equal(t, "test-ecid-2", event.GetRadioMeasReportPerCell().Ecgi.Ecid)
+	assert.Equal(t, "test-plmnid-2", event.GetRadioMeasReportPerCell().Ecgi.PlmnId)
+
+	event = <-watchCh2
+	assert.Equal(t, "test-ecid-2", event.GetRadioMeasReportPerCell().Ecgi.Ecid)
+	assert.Equal(t, "test-plmnid-2", event.GetRadioMeasReportPerCell().Ecgi.PlmnId)
 
 	telemetry3 := sb.TelemetryMessage{
 		MessageType: sb.MessageType_RADIO_MEAS_REPORT_PER_UE,
@@ -106,5 +130,13 @@ func TestStore(t *testing.T) {
 	value3, err := testStore.Get(id3)
 	assert.Nil(t, err)
 	assert.Equal(t, value3.MessageType.String(), sb.MessageType_RADIO_MEAS_REPORT_PER_UE.String())
+
+	event = <-watchCh1
+	assert.Equal(t, "test-ecid-3", event.GetRadioMeasReportPerUE().Ecgi.Ecid)
+	assert.Equal(t, "test-plmnid-3", event.GetRadioMeasReportPerUE().Ecgi.PlmnId)
+
+	event = <-watchCh2
+	assert.Equal(t, "test-ecid-3", event.GetRadioMeasReportPerUE().Ecgi.Ecid)
+	assert.Equal(t, "test-plmnid-3", event.GetRadioMeasReportPerUE().Ecgi.PlmnId)
 
 }

--- a/pkg/store/updates/store.go
+++ b/pkg/store/updates/store.go
@@ -136,8 +136,8 @@ func (s *updatesStore) Put(update sb.ControlUpdate) error {
 	id := getKey(update)
 	s.mu.Lock()
 	s.controlUpdates[id] = update
-	s.mu.Unlock()
 	s.enqueueEvent(update)
+	s.mu.Unlock()
 	return nil
 }
 
@@ -162,6 +162,7 @@ func (s *updatesStore) Watch(ch chan<- sb.ControlUpdate, opts ...WatchOption) er
 	done := make(chan struct{})
 	go func() {
 		s.mu.Lock()
+		close(done)
 		if options.replay {
 			for _, update := range s.controlUpdates {
 				ch <- update
@@ -169,7 +170,6 @@ func (s *updatesStore) Watch(ch chan<- sb.ControlUpdate, opts ...WatchOption) er
 		}
 		s.watchers = append(s.watchers, ch)
 		s.mu.Unlock()
-		close(done)
 	}()
 	<-done
 	return nil

--- a/pkg/store/updates/store_test.go
+++ b/pkg/store/updates/store_test.go
@@ -23,6 +23,11 @@ import (
 
 func TestStore(t *testing.T) {
 	testStore, err := NewStore()
+
+	watchCh1 := make(chan sb.ControlUpdate)
+	err = testStore.Watch(watchCh1)
+	assert.NoError(t, err)
+
 	assert.Nil(t, err)
 	assert.NotNil(t, testStore)
 	controlUpdate1 := sb.ControlUpdate{
@@ -51,6 +56,17 @@ func TestStore(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, value1.MessageType.String(), sb.MessageType_CELL_CONFIG_REPORT.String())
 
+	event := <-watchCh1
+	assert.Equal(t, "test-ecid", event.GetCellConfigReport().Ecgi.Ecid)
+	assert.Equal(t, "test-plmnid", event.GetCellConfigReport().Ecgi.PlmnId)
+
+	watchCh2 := make(chan sb.ControlUpdate)
+	err = testStore.Watch(watchCh2, WithReplay())
+
+	event = <-watchCh2
+	assert.Equal(t, "test-ecid", event.GetCellConfigReport().Ecgi.Ecid)
+	assert.Equal(t, "test-plmnid", event.GetCellConfigReport().Ecgi.PlmnId)
+
 	controlUpdate2 := sb.ControlUpdate{
 		MessageType: sb.MessageType_CELL_CONFIG_REPORT,
 		S: &sb.ControlUpdate_CellConfigReport{
@@ -77,6 +93,14 @@ func TestStore(t *testing.T) {
 	value2, err := testStore.Get(id2)
 	assert.Nil(t, err)
 	assert.Equal(t, value2.MessageType.String(), sb.MessageType_CELL_CONFIG_REPORT.String())
+
+	event = <-watchCh1
+	assert.Equal(t, "test-ecid-2", event.GetCellConfigReport().Ecgi.Ecid)
+	assert.Equal(t, "test-plmnid-2", event.GetCellConfigReport().Ecgi.PlmnId)
+
+	event = <-watchCh2
+	assert.Equal(t, "test-ecid-2", event.GetCellConfigReport().Ecgi.Ecid)
+	assert.Equal(t, "test-plmnid-2", event.GetCellConfigReport().Ecgi.PlmnId)
 
 	controlUpdate3 := sb.ControlUpdate{
 		MessageType: sb.MessageType_UE_ADMISSION_STATUS,
@@ -106,5 +130,13 @@ func TestStore(t *testing.T) {
 	value3, err := testStore.Get(id3)
 	assert.Nil(t, err)
 	assert.Equal(t, value3.MessageType.String(), sb.MessageType_UE_ADMISSION_STATUS.String())
+
+	event = <-watchCh1
+	assert.Equal(t, "test-ecid-3", event.GetUEAdmissionStatus().Ecgi.Ecid)
+	assert.Equal(t, "test-plmnid-3", event.GetUEAdmissionStatus().Ecgi.PlmnId)
+
+	event = <-watchCh2
+	assert.Equal(t, "test-ecid-3", event.GetUEAdmissionStatus().Ecgi.Ecid)
+	assert.Equal(t, "test-plmnid-3", event.GetUEAdmissionStatus().Ecgi.PlmnId)
 
 }

--- a/pkg/store/updates/store_test.go
+++ b/pkg/store/updates/store_test.go
@@ -23,13 +23,13 @@ import (
 
 func TestStore(t *testing.T) {
 	testStore, err := NewStore()
+	assert.NoError(t, err)
+	assert.NotNil(t, testStore)
 
 	watchCh1 := make(chan sb.ControlUpdate)
 	err = testStore.Watch(watchCh1)
 	assert.NoError(t, err)
 
-	assert.Nil(t, err)
-	assert.NotNil(t, testStore)
 	controlUpdate1 := sb.ControlUpdate{
 		MessageType: sb.MessageType_CELL_CONFIG_REPORT,
 		S: &sb.ControlUpdate_CellConfigReport{
@@ -62,6 +62,7 @@ func TestStore(t *testing.T) {
 
 	watchCh2 := make(chan sb.ControlUpdate)
 	err = testStore.Watch(watchCh2, WithReplay())
+	assert.NoError(t, err)
 
 	event = <-watchCh2
 	assert.Equal(t, "test-ecid", event.GetCellConfigReport().Ecgi.Ecid)


### PR DESCRIPTION
This PR adds support for streams to the northbound API via the `Subscribe` flag already implemented in northbound RPCs. To support streams, new `Watch` methods suitable for future Atomix/distributed stores are added to store APIs. When the `Subscribe` flag is `true`, the new `Watch` methods are used to stream updates to clients.

The handover application is also updated to use streaming northbound APIs. To do so, the handover app creates a state machine based on the NB API responses, allowing it to react to the system state at specific points in time as they're represented in the store. This is just a PoC. Ultimately, we might want to abstract the management of state machines for this use case.

This PR is a work in progress. I haven't even begun to test it but wanted to begin the review process. This PR also addresses some Golang code style/convention issues. I will go through the code and add some context to some of those changes.