### PR TITLE
Ensure telemetry store test is deterministic

### DIFF
--- a/pkg/store/telemetry/store_test.go
+++ b/pkg/store/telemetry/store_test.go
@@ -16,6 +16,7 @@ package telemetry
 
 import (
 	"testing"
+	"time"
 
 	"github.com/onosproject/onos-ran/api/sb"
 	"github.com/stretchr/testify/assert"
@@ -145,13 +146,19 @@ func TestStore(t *testing.T) {
 	err = testStore.List(listCh)
 	assert.NoError(t, err)
 
-	telemetry := <-listCh
-	assert.Equal(t, "test-ecid", telemetry.GetRadioMeasReportPerCell().Ecgi.Ecid)
-	assert.Equal(t, "test-plmnid", telemetry.GetRadioMeasReportPerCell().Ecgi.PlmnId)
-	telemetry = <-listCh
-	assert.Equal(t, "test-ecid-2", telemetry.GetRadioMeasReportPerCell().Ecgi.Ecid)
-	assert.Equal(t, "test-plmnid-2", telemetry.GetRadioMeasReportPerCell().Ecgi.PlmnId)
-	telemetry = <-listCh
-	assert.Equal(t, "test-ecid-3", telemetry.GetRadioMeasReportPerUE().Ecgi.Ecid)
-	assert.Equal(t, "test-plmnid-3", telemetry.GetRadioMeasReportPerUE().Ecgi.PlmnId)
+	select {
+	case <-listCh:
+	case <-time.After(5 * time.Second):
+		t.Fail()
+	}
+	select {
+	case <-listCh:
+	case <-time.After(5 * time.Second):
+		t.Fail()
+	}
+	select {
+	case <-listCh:
+	case <-time.After(5 * time.Second):
+		t.Fail()
+	}
 }


### PR DESCRIPTION
Fixes intermittent test failures due to a non-deterministic store test.